### PR TITLE
Add serial_num field into device_info

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -37,6 +37,7 @@ BACKEND_ASIC_SUB_ROLE = "BackEnd"
 CHASSIS_INFO_TABLE = 'CHASSIS_INFO|chassis {}'
 CHASSIS_INFO_CARD_NUM_FIELD = 'module_num'
 CHASSIS_INFO_SERIAL_FIELD = 'serial'
+CHASSIS_INFO_SERIAL_NUM_FIELD = 'serial_num'
 CHASSIS_INFO_MODEL_FIELD = 'model'
 CHASSIS_INFO_REV_FIELD = 'revision'
 
@@ -371,7 +372,7 @@ def get_platform_info():
 
 def get_chassis_info():
     """
-    This function is used to get the Chassis serial / model / rev number
+    This function is used to get the Chassis serial / model / rev number / serial number
     """
 
     chassis_info_dict = {}
@@ -385,6 +386,7 @@ def get_chassis_info():
         chassis_info_dict['serial'] = db.get(db.STATE_DB, table, CHASSIS_INFO_SERIAL_FIELD)
         chassis_info_dict['model'] = db.get(db.STATE_DB, table, CHASSIS_INFO_MODEL_FIELD)
         chassis_info_dict['revision'] = db.get(db.STATE_DB, table, CHASSIS_INFO_REV_FIELD)
+        chassis_info_dict['serial_num'] = db.get(db.STATE_DB, table, CHASSIS_INFO_SERIAL_NUM_FIELD)
     except Exception:
         pass
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
because the new added serial_num field by chassis_db_init script which is used to initialize chassis info in database should also have a way to be allowed to access. Introduce this field in get_chassis_info so that it can be called to get by SONiC CLI utilities

#### How I did it
In get_chassis_info function, get 'serial_num' field from STATE_DB and store the value into chassis_info_dict

#### How to verify it
After the merge of the related CLI utilities change, use "show version" command to check whether the "Serial Number" is the desired value.

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [x] 202012
- [x] 202106

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Add serial_num field db.get operation in device_info

#### A picture of a cute animal (not mandatory but encouraged)

